### PR TITLE
Added manual step to add coffee-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Requirements:
 ```bash
 npm install -g yo generator-hubot
 yo hubot
+npm install coffee-script --save
 ```
 
 2. Fill in the prompts appropriatly. For Adapter type 'orky'


### PR DESCRIPTION
By default, coffee-script is not added to node_modules and therefore help commands (hubot-help) do not work. This manual step fixes that problem.